### PR TITLE
Add missing required fields to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,5 +3,7 @@ version=0.0.1+arduino-1
 author=Jacques Michiels <jacques@smartmakers.de>
 maintainer=Jacques Michiels <jacques@smartmakers.de>
 sentence=Small library for non blocking control of a led.
+paragraph=
 category=Display
+url=https://github.com/smartmakers/wave
 architectures=*


### PR DESCRIPTION
When a required field is missing from library.properties the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format